### PR TITLE
Feat(drawText): add justify text functionnality

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ var canvasTxt = window.canvasTxt.default
 | `fontVariant` |   `''`   | Font variant, same as css font-variant. Examples: `small-caps`, `slashed-zero` |
 | `fontWeight`  |   `''`   | Font weight, same as css font-weight. Examples: `bold`, `100`                  |
 | `lineHeight`  |  `null`  | Line height of the text, if set to null it tries to auto-detect the value      |
+|   `justify`   | `false`  | Justify text if `true`, it will insert spaces between words when necessary.    |
 
 ## Methods
 
@@ -117,6 +118,7 @@ canvasTxt.fontSize = 20
 canvasTxt.align = 'left'
 canvasTxt.lineHeight = 60
 canvasTxt.debug = true //shows debug info
+canvasTxt.justify = false
 canvasTxt.drawText(ctx, txt, 100, 200, 200, 200)
 ```
 

--- a/public/main.js
+++ b/public/main.js
@@ -13,6 +13,7 @@ canvasTxt.fontVariant = 'small-caps'
 // canvasTxt.debug = true
 canvasTxt.align = 'center'
 canvasTxt.vAlign = 'middle'
+// canvasTxt.justify = true
 
 let { height } = canvasTxt.drawText(ctx, txt, 120, 120, 250, 200)
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+// Hair space character for precise justification
+const SPACE = '\u200a'
+
 var canvasTxt = {
   debug: false,
   align: 'center',
@@ -8,6 +11,16 @@ var canvasTxt = {
   fontVariant: '',
   font: 'Arial',
   lineHeight: null,
+  justify: false,
+  /**
+   *
+   * @param {CanvasRenderingContext2D} ctx
+   * @param {string} mytext
+   * @param {number} x
+   * @param {number} y
+   * @param {number} width
+   * @param {number} height
+   */
   drawText: function(ctx, mytext, x, y, width, height) {
     // Parse all to integers
     ;[x, y, width, height] = [x, y, width, height].map(el => parseInt(el))
@@ -52,6 +65,8 @@ var canvasTxt = {
     let textarray = []
     let temptextarray = mytext.split('\n')
 
+    const spaceWidth = this.justify ? ctx.measureText(SPACE).width : 0
+
     temptextarray.forEach(txtt => {
       let textwidth = ctx.measureText(txtt).width
       if (textwidth <= width) {
@@ -83,6 +98,10 @@ var canvasTxt = {
             }
             texttoprint = temptext.substr(0, textlen)
           }
+
+          texttoprint = this.justify
+            ? this.justifyLine(ctx, texttoprint, spaceWidth, SPACE, width)
+            : texttoprint
 
           temptext = temptext.substr(textlen)
           textwidth = ctx.measureText(temptext).width
@@ -161,6 +180,48 @@ var canvasTxt = {
     document.body.removeChild(el)
 
     return height
+  },
+  /**
+   * This function will insert spaces between words in a line in order
+   * to raise the line width to the box width.
+   * The spaces are evenly spread in the line, and extra spaces (if any) are inserted
+   * between the first words.
+   *
+   * It returns the justified text.
+   *
+   * @param {CanvasRenderingContext2D} ctx
+   * @param {string} line
+   * @param {number} spaceWidth
+   * @param {string} spaceChar
+   * @param {number} width
+   */
+  justifyLine: function(ctx, line, spaceWidth, spaceChar, width) {
+    const text = line.trim()
+
+    const lineWidth = ctx.measureText(text).width
+
+    const nbSpaces = text.split(/\s+/).length - 1
+    const nbSpacesToInsert = Math.floor((width - lineWidth) / spaceWidth)
+
+    if (nbSpaces <= 0 || nbSpacesToInsert <= 0) return text
+
+    // We insert at least nbSpacesMinimum and we add extraSpaces to the first words
+    const nbSpacesMinimum = Math.floor(nbSpacesToInsert / nbSpaces)
+    let extraSpaces = nbSpacesToInsert - nbSpaces * nbSpacesMinimum
+
+    let spaces = []
+    for (let i = 0; i < nbSpacesMinimum; i++) {
+      spaces.push(spaceChar)
+    }
+    spaces = spaces.join('')
+
+    const justifiedText = text.replace(/\s+/g, match => {
+      const allSpaces = extraSpaces > 0 ? spaces + spaceChar : spaces
+      extraSpaces--
+      return match + allSpaces
+    })
+
+    return justifiedText
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -87,6 +87,9 @@ var canvasTxt = {
             texttoprint = temptext.substr(0, textlen)
             textpixlen = ctx.measureText(temptext.substr(0, textlen)).width
           }
+          // Remove last character that was out of the box
+          textlen--
+          texttoprint = texttoprint.substr(0, textlen)
           //if statement ensures a new line only happens at a space, and not amidst a word
           const backup = textlen
           if (temptext.substr(textlen, 1) != ' ') {


### PR DESCRIPTION
This is linked to #18 .
Please tell me what you think of this, I tested it with real texts and it works correctly thanks to god.

Note: I used `Math.floor` which causes some issues with babel minify plugin in dev. I had to use this in babel config : 
 ```
"minify", {
      "keepFnName": true,
      "builtIns": false
    }
```
I don't know why, I saw this in this issue : https://github.com/babel/minify/issues/904