### PR TITLE
Fixes window undefined in node env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Node.js Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test
+        env:
+          CI: true

--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,7 @@ var canvasTxt = {
     })
     const charHeight = this.lineHeight
       ? this.lineHeight
-      : this.getTextHeight(mytext, this.font, this.fontSize) //close approximation of height with width
+      : this.getTextHeight(ctx, mytext, style) //close approximation of height with width
     const vheight = charHeight * (textarray.length - 1)
     const negoffset = vheight / 2
 
@@ -167,20 +167,17 @@ var canvasTxt = {
     return { height: TEXT_HEIGHT }
   },
   // Calculate Height of the font
-  getTextHeight: function(txt, font, size) {
-    const el = document.createElement('div')
+  getTextHeight: function(ctx, text, style) {
+    const previousTextBaseline = ctx.textBaseline
+    const previousFont = ctx.font
 
-    el.style.cssText =
-      'position:fixed;padding:0;left:-9999px;top:-9999px;font:' +
-      font +
-      ';font-size:' +
-      size +
-      'px'
-    el.textContent = txt
+    ctx.textBaseline = 'bottom'
+    ctx.font = style
+    const { actualBoundingBoxAscent: height } = ctx.measureText(text)
 
-    document.body.appendChild(el)
-    const height = parseInt(getComputedStyle(el).getPropertyValue('height'), 10)
-    document.body.removeChild(el)
+    // Reset baseline
+    ctx.textBaseline = previousTextBaseline
+    ctx.font = previousFont
 
     return height
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 // Hair space character for precise justification
 const SPACE = '\u200a'
 
-var canvasTxt = {
+const canvasTxt = {
   debug: false,
   align: 'center',
   vAlign: 'middle',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,8 @@ module.exports = {
     path: path.resolve(__dirname, 'build'),
     library: 'canvasTxt',
     libraryTarget: 'umd',
-    umdNamedDefine: true
+    umdNamedDefine: true,
+    globalObject: 'typeof self !== \'undefined\' ? self : this'
   },
   module: {
     rules: [


### PR DESCRIPTION
Use in a node environment using node-canvas.

- [X] Fixes Webpack bug ([window header export](https://github.com/webpack/webpack/issues/6522#issuecomment-371120689))
- [x] More robust Text Height calculation (Current one uses [dom methods](https://github.com/geongeorge/Canvas-Txt/blob/cb853503b8fbccd216d9071d26ec40f5c073a600/src/index.js#L170))