### PR TITLE
Fix #34 Whitespace returning wrong width

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,7 +106,7 @@ const canvasTxt = {
             ? this.justifyLine(ctx, texttoprint, spaceWidth, SPACE, width)
             : texttoprint
 
-          temptext = temptext.substr(textlen)
+          temptext = temptext.substr(textlen).trim()
           textwidth = ctx.measureText(temptext).width
           textarray.push(texttoprint)
         }


### PR DESCRIPTION
Unless this has unwanted consequences in scenarios that I might have missed, this should fix #34 and return the precise with and line text.