### PR TITLE
type: support OffscreenCanvasRenderingContext2D

### DIFF
--- a/src/canvas-txt/index.ts
+++ b/src/canvas-txt/index.ts
@@ -32,7 +32,7 @@ const defaultConfig = {
 }
 
 function drawText(
-  ctx: CanvasRenderingContext2D,
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D,
   myText: string,
   inputConfig: CanvasTextConfig
 ) {

--- a/src/canvas-txt/lib/justify.ts
+++ b/src/canvas-txt/lib/justify.ts
@@ -1,5 +1,5 @@
 export interface JustifyLineProps {
-  ctx: CanvasRenderingContext2D
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
   line: string
   spaceWidth: number
   spaceChar: string

--- a/src/canvas-txt/lib/split-text.ts
+++ b/src/canvas-txt/lib/split-text.ts
@@ -4,7 +4,7 @@ import justifyLine from './justify'
 const SPACE = '\u{200a}'
 
 export interface SplitTextProps {
-  ctx: CanvasRenderingContext2D
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
   text: string
   justify: boolean
   width: number

--- a/src/canvas-txt/lib/text-height.ts
+++ b/src/canvas-txt/lib/text-height.ts
@@ -1,5 +1,5 @@
 interface GetTextHeightProps {
-  ctx: CanvasRenderingContext2D
+  ctx: CanvasRenderingContext2D | OffscreenCanvasRenderingContext2D
   text: string
   style: string
 }


### PR DESCRIPTION
sometime we use OffscreenCanvas instead of HTMLCanvasElemnt, so we should support OffscreenCanvasRenderingContext2D